### PR TITLE
Implement missing image imports for media_type CAROUSEL_ALBUM and VIDEO

### DIFF
--- a/src/Builder/Type/PrivateBuilder.php
+++ b/src/Builder/Type/PrivateBuilder.php
@@ -152,11 +152,12 @@ class PrivateBuilder
         }
 
         $mediaType = $element['media_type'];
+        $posterUrl = in_array($mediaType, ['IMAGE', 'CAROUSEL_ALBUM']) ? $element['media_url'] : ($mediaType === 'VIDEO' ? $element['thumbnail_url'] : null);
 
         $socialPost->setContent($element['caption'] ?? null);
         $socialPost->setSocialCreationDate(is_string($element['timestamp']) ? Carbon::create($element['timestamp']) : null);
         $socialPost->setUrl($element['permalink']);
-        $socialPost->setPosterUrl($mediaType === 'IMAGE' ? $element['media_url'] : null);
+        $socialPost->setPosterUrl($posterUrl);
 
         $data->setTransformedElement($socialPost);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes?
| Deprecations? | no
| Fixed tickets | 

Import of images for media_type CAROUSEL_ALBUM and VIDEO is currently not supported. This pull request implements this missing feature. See: https://developers.facebook.com/docs/instagram-basic-display-api/reference/media/
